### PR TITLE
zero price analysis added

### DIFF
--- a/FutureDatenCotton.m
+++ b/FutureDatenCotton.m
@@ -108,6 +108,23 @@ settlePrices = futurePrices(:, {'Date', 'Settle', 'Ticker'});
 
 prices = unstack(settlePrices, 'Settle', 'Ticker');
 
+% important: unstack does not guarantee sorting with regards to dates
+prices = sortrows(prices, 'Date'); 
+
+%% get number of zero prices per column
+
+nZeros = varfun(@(x)sum(x == 0), prices(:, 2:end));
+nZeros.Properties.VariableNames = tabnames(prices(:, 2:end));
+
+% show futures with zero prices
+xxInds = nZeros{1, :} > 0;
+nZeros(1, xxInds)
+
+plot(prices.Date, prices{:, tabnames(nZeros(:, xxInds))})
+datetick 'x'
+grid on
+grid minor
+
 %%
 
 plot(prices.Date, prices{:, 2:end})


### PR DESCRIPTION
I just added a few lines at the end of the cotton data download script. There I just select all price series that contain zero prices and plot them. If you look at the plot you will see that zero prices only occur at the end of the prices, when the future probably has expired already. In these cases we would just set the prices to NaN / cut them off. You probably just missed this pattern since you forgot to sort the prices with regards to dates.

Please do a more formal programmatic check to guarantee that zero prices are only allowed if no real prices follow anymore, such that they really only occur at the end of the individual price series.
